### PR TITLE
refactor: Remove Breadcrumbs from multiple compliance library pages for cleaner UI

### DIFF
--- a/app/admin/compliance-library/controls/create/page.tsx
+++ b/app/admin/compliance-library/controls/create/page.tsx
@@ -12,7 +12,6 @@ const breadcrumbItems = [
 const CreateControlPage = () => {
     return (
         <div className="min-h-screen bg-[#FAFAFA] flex flex-col items-start">
-            <Breadcrumbs items={breadcrumbItems} />
             <h1 className="text-3xl text-[#171717] font-bold mt-3 mb-6">Create Control</h1>
             <ControlForm />
         </div>

--- a/app/admin/compliance-library/controls/details/[id]/page.tsx
+++ b/app/admin/compliance-library/controls/details/[id]/page.tsx
@@ -3,7 +3,6 @@
 
 import React from 'react'
 import ControlsDetails from '@/components/admin/controls/controlDetail/ControlsDetails'
-import Breadcrumbs from '@/components/custom/Breadcrumbs';
 
 interface ControlDetailsPageProps {
   params: Promise<{
@@ -13,13 +12,9 @@ interface ControlDetailsPageProps {
 
 const page = async ({ params }: ControlDetailsPageProps) => {
   const { id } = await params;
-  const breadcrumbItems = [
-    { label: 'Controls', href: "/admin/compliance-library/controls" },
-    { label: 'Details' },
-  ];
+
   return (
     <div>
-      <Breadcrumbs items={breadcrumbItems} />
       <div className='flex items-center justify-between mt-2 mb-10'>
         <h1 className="font-bold text-3xl text-neutral-900">Control Details</h1>
       </div>

--- a/app/admin/compliance-library/controls/edit/[id]/page.tsx
+++ b/app/admin/compliance-library/controls/edit/[id]/page.tsx
@@ -1,7 +1,6 @@
 
 
 import ControlForm from '@/components/admin/controls/ControlForm/ControlForm';
-import Breadcrumbs from '@/components/custom/Breadcrumbs'
 import React from 'react'
 
 interface EditControlPageProps {
@@ -10,16 +9,10 @@ interface EditControlPageProps {
     }>;
 }
 
-const breadcrumbItems = [
-    { label: 'Controls', href: '/admin/compliance-library/controls' },
-    { label: 'Edit' },
-];
-
 const EditControlPage = async ({ params }: EditControlPageProps) => {
     const { id } = await params;
     return (
         <div className="min-h-screen bg-[#FAFAFA] flex flex-col items-start">
-            <Breadcrumbs items={breadcrumbItems} />
             <h1 className="text-3xl text-[#171717] font-bold mt-3 mb-6">Edit Control</h1>
             <ControlForm controlId={id} mode="edit" />
         </div>

--- a/app/admin/compliance-library/controls/page.tsx
+++ b/app/admin/compliance-library/controls/page.tsx
@@ -10,7 +10,6 @@ const page = () => {
   const breadcrumbItems = [{ label: "Controls" }, { label: "List" }];
   return (
     <div>
-      <Breadcrumbs items={breadcrumbItems} />
       <div className="flex items-center justify-between mt-2 mb-10">
         <h1 className="font-bold text-4xl text-neutral-900">Controls</h1>
         <Link href="/admin/compliance-library/controls/create">

--- a/app/admin/compliance-library/frameworks/page.tsx
+++ b/app/admin/compliance-library/frameworks/page.tsx
@@ -2,19 +2,12 @@
 
 import React from 'react';
 import FrameworkTable from '@/components/admin/frameworks/createFramework/FrameworkTable';
-import Breadcrumbs from '@/components/custom/Breadcrumbs';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 
 const Page = () => {
-  const breadcrumbItems = [
-    { label: 'Frameworks' },
-    { label: 'List' },
-  ];
-
   return (
     <React.Fragment>
-      <Breadcrumbs items={breadcrumbItems} />
       <div className='flex items-center justify-between mt-2 mb-10'>
         <h1 className="font-bold text-4xl text-neutral-900">Frameworks</h1>
         <Link href="/admin/compliance-library/frameworks/create">

--- a/app/admin/compliance-library/requirement-controls/page.tsx
+++ b/app/admin/compliance-library/requirement-controls/page.tsx
@@ -2,13 +2,10 @@ import RequirementControlsList from "@/components/admin/requirement-controls/Req
 import React from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import Breadcrumbs from "@/components/custom/Breadcrumbs";
 
 const page = () => {
-  const breadcrumbItems = [{ label: "Requirement Controls" }, { label: "List" }];
   return (
     <div>
-      <Breadcrumbs items={breadcrumbItems} />
       <div className="flex items-center justify-between mt-2 mb-10">
         <h1 className="font-bold text-4xl text-neutral-900">Requirement Controls</h1>
         <Link href="/admin/compliance-library/requirement-controls/create">

--- a/components/admin/compliance-evidence/ComplianceEvidenceForm.tsx
+++ b/components/admin/compliance-evidence/ComplianceEvidenceForm.tsx
@@ -99,8 +99,9 @@ export default function ComplianceEvidenceForm({
         label: `${req.reference}${req.requirement_text ? ` - ${req.requirement_text.substring(0, 50)}` : ""}`,
       })) || [];
 
-    if (complianceEvidence?.requirement) {
-      const rcRequirement = complianceEvidence.requirement;
+    const rcRequirement = complianceEvidence?.requirement;
+    const rcRequirementId = complianceEvidence?.requirement_id;
+    if (rcRequirement) {
       const exists = base.some((opt) => opt.value === rcRequirement.id.toString());
       if (!exists) {
         base.unshift({
@@ -110,6 +111,14 @@ export default function ComplianceEvidenceForm({
               ? ` - ${rcRequirement.requirement_text.substring(0, 50)}`
               : ""
           }`,
+        });
+      }
+    } else if (rcRequirementId) {
+      const exists = base.some((opt) => opt.value === rcRequirementId.toString());
+      if (!exists) {
+        base.unshift({
+          value: rcRequirementId.toString(),
+          label: `Requirement #${rcRequirementId}`,
         });
       }
     }
@@ -124,13 +133,22 @@ export default function ComplianceEvidenceForm({
         label: `${ctrl.reference} - ${ctrl.name}`,
       })) || [];
 
-    if (complianceEvidence?.control) {
-      const rcControl = complianceEvidence.control;
+    const rcControl = complianceEvidence?.control;
+    const rcControlId = complianceEvidence?.control_id;
+    if (rcControl) {
       const exists = base.some((opt) => opt.value === rcControl.id.toString());
       if (!exists) {
         base.unshift({
           value: rcControl.id.toString(),
           label: `${rcControl.reference} - ${rcControl.name}`,
+        });
+      }
+    } else if (rcControlId) {
+      const exists = base.some((opt) => opt.value === rcControlId.toString());
+      if (!exists) {
+        base.unshift({
+          value: rcControlId.toString(),
+          label: `Control #${rcControlId}`,
         });
       }
     }
@@ -351,13 +369,6 @@ export default function ComplianceEvidenceForm({
 
   return (
     <div className="min-h-screen bg-[#FAFAFA] px-6 py-6">
-      <Breadcrumbs
-        items={[
-          { label: "Compliance Library", href: "/admin/compliance-library/frameworks" },
-          { label: "Compliance Evidence", href: "/admin/compliance-library/compliance-evidences" },
-          { label: mode === "create" ? "Create" : "Edit" },
-        ]}
-      />
       <div className="mt-6 mb-8">
         <h1 className="text-3xl text-[#171717] font-bold">
           {mode === "create" ? "Create Compliance Evidence" : "Edit Compliance Evidence"}
@@ -374,6 +385,7 @@ export default function ComplianceEvidenceForm({
                 Control <span className="text-red-500">*</span>
               </Label>
               <Select
+                key={`control-${formData.control_id || "none"}`}
                 value={formData.control_id ? String(formData.control_id) : ""}
                 onValueChange={(value) => handleInputChange("control_id", Number(value))}
                 disabled={isLoading}
@@ -403,6 +415,7 @@ export default function ComplianceEvidenceForm({
             <div>
               <Label className="text-sm font-medium text-gray-900">Requirement</Label>
               <Select
+                key={`requirement-${formData.requirement_id || "none"}`}
                 value={formData.requirement_id ? String(formData.requirement_id) : "null"}
                 onValueChange={(value) =>
                   handleInputChange("requirement_id", value === "null" ? null : Number(value))
@@ -434,6 +447,7 @@ export default function ComplianceEvidenceForm({
             <div>
               <Label className="text-sm font-medium text-gray-900">AI Model</Label>
               <Select
+                key={`ai-model-${formData.ai_model_id || "none"}`}
                 value={formData.ai_model_id ? String(formData.ai_model_id) : "null"}
                 onValueChange={(value) =>
                   handleInputChange("ai_model_id", value === "null" ? null : Number(value))
@@ -465,6 +479,7 @@ export default function ComplianceEvidenceForm({
                 Artifact Type <span className="text-red-500">*</span>
               </Label>
               <Select
+                key={`artifact-type-${formData.artifact_type || "none"}`}
                 value={formData.artifact_type}
                 onValueChange={(value) =>
                   handleInputChange("artifact_type", value as ComplianceEvidenceArtifactTypeEnum)
@@ -571,6 +586,7 @@ export default function ComplianceEvidenceForm({
             <div>
               <Label className="text-sm font-medium text-gray-900">Collected By</Label>
               <Select
+                key={`collected-by-${formData.collected_by || "none"}`}
                 value={formData.collected_by ? String(formData.collected_by) : "null"}
                 onValueChange={(value) =>
                   handleInputChange("collected_by", value === "null" ? null : Number(value))
@@ -600,6 +616,7 @@ export default function ComplianceEvidenceForm({
             <div>
               <Label className="text-sm font-medium text-gray-900">Review Outcome</Label>
               <Select
+                key={`review-outcome-${formData.review_outcome || "none"}`}
                 value={formData.review_outcome || "null"}
                 onValueChange={(value) =>
                   handleInputChange(
@@ -628,6 +645,7 @@ export default function ComplianceEvidenceForm({
             <div>
               <Label className="text-sm font-medium text-gray-900">Reviewed By</Label>
               <Select
+                key={`reviewed-by-${formData.reviewed_by || "none"}`}
                 value={formData.reviewed_by ? String(formData.reviewed_by) : "null"}
                 onValueChange={(value) =>
                   handleInputChange("reviewed_by", value === "null" ? null : Number(value))

--- a/components/admin/compliance-evidence/ComplianceEvidenceList.tsx
+++ b/components/admin/compliance-evidence/ComplianceEvidenceList.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { DataTable } from "@/components/custom/DataTable";
-import Breadcrumbs from "@/components/custom/Breadcrumbs";
 import { useComplianceEvidences, useComplianceEvidenceMutations } from "@/hooks/admin/useComplianceEvidence";
 import { ComplianceEvidence, ComplianceEvidenceFilters } from "@/interfaces/ComplianceEvidence";
 import { ColumnDef } from "@tanstack/react-table";
@@ -39,12 +38,6 @@ export default function ComplianceEvidenceList() {
     entityTypeName: "Compliance Evidence",
     onSuccess: () => refresh(),
   });
-
-  const breadcrumbItems = [
-    { label: "Compliance Library", href: "/admin/compliance-library/frameworks" },
-    { label: "Compliance Evidence", href: "/admin/compliance-library/compliance-evidences" },
-    { label: "List" },
-  ];
 
   const handleSearchTerm = (searchTerm: string) => {
     setFilters((prev) => ({
@@ -194,7 +187,6 @@ export default function ComplianceEvidenceList() {
   if (error) {
     return (
       <div className="min-h-screen bg-[#FAFAFA] px-6 py-6">
-        <Breadcrumbs items={breadcrumbItems} />
         <Alert variant="destructive" className="mt-6">
           <AlertCircle className="h-4 w-4" />
           <AlertTitle>Error</AlertTitle>
@@ -206,7 +198,6 @@ export default function ComplianceEvidenceList() {
 
   return (
     <div className="min-h-screen bg-[#FAFAFA] px-6 py-6">
-      <Breadcrumbs items={breadcrumbItems} />
       <div className="flex items-center justify-between mt-6 mb-8">
         <h1 className="text-3xl text-[#171717] font-bold">Compliance Evidence</h1>
         <Link href="/admin/compliance-library/compliance-evidences/create">

--- a/components/admin/controls/ControlForm/ControlForm.tsx
+++ b/components/admin/controls/ControlForm/ControlForm.tsx
@@ -228,6 +228,7 @@ const ControlForm = ({ controlId, mode = "create" }: ControlFormProps) => {
               Testing Method <span className="text-red-500">*</span>
             </Label>
             <Select
+              key={`testing-method-${formData.testing_method || "none"}`}
               value={formData.testing_method}
               onValueChange={(value) => handleInputChange("testing_method", value as ControlTestingMethodEnum)}
               disabled={isLoading}
@@ -252,6 +253,7 @@ const ControlForm = ({ controlId, mode = "create" }: ControlFormProps) => {
               Testing Frequency <span className="text-red-500">*</span>
             </Label>
             <Select
+              key={`testing-frequency-${formData.testing_frequency || "none"}`}
               value={formData.testing_frequency}
               onValueChange={(value) =>
                 handleInputChange("testing_frequency", value as ControlTestingFrequencyEnum)
@@ -304,6 +306,7 @@ const ControlForm = ({ controlId, mode = "create" }: ControlFormProps) => {
               Status <span className="text-red-500">*</span>
             </Label>
             <Select
+              key={`status-${formData.status || "none"}`}
               value={formData.status}
               onValueChange={(value) => handleInputChange("status", value as ControlStatusEnum)}
               disabled={isLoading}

--- a/components/admin/frameworks/createFramework/AdditionalInformation.tsx
+++ b/components/admin/frameworks/createFramework/AdditionalInformation.tsx
@@ -208,7 +208,8 @@ export default function AdditionalInformation({
                         <Label className="text-[#171717] text-sm font-medium" htmlFor="binding_level">
                             Binding Level
                         </Label>
-                        <Select
+                        <Select 
+                            key={`binding-level-${bindingLevel || "none"}`}
                             value={bindingLevel || ""}
                             onValueChange={(value) => handleBindingLevelChange(value as BindingLevel)}
                         >
@@ -235,6 +236,7 @@ export default function AdditionalInformation({
                             Sector Applicability
                         </Label>
                         <CustomMultiSelect
+                            key={`sector-applicability-${sectorApplicability.join(",")}`}
                             options={sectorApplicabilityOptions}
                             value={sectorApplicability}
                             onChange={handleSectorApplicabilityChange}
@@ -247,6 +249,7 @@ export default function AdditionalInformation({
                             Risk Class Coverage
                         </Label>
                         <CustomMultiSelect
+                            key={`risk-class-coverage-${riskClassCoverage.join(",")}`}
                             options={riskClassCoverageOptions}
                             value={riskClassCoverage}
                             onChange={handleRiskClassCoverageChange}
@@ -263,6 +266,7 @@ export default function AdditionalInformation({
                             Certification / Attestation
                         </Label>
                         <CustomMultiSelect
+                            key={`certification-attestation-${certificationAttestation.join(",")}`}
                             options={certificationAttestationOptions}
                             value={certificationAttestation}
                             onChange={handleCertificationAttestationChange}
@@ -275,6 +279,7 @@ export default function AdditionalInformation({
                             Assessment Mode
                         </Label>
                         <CustomMultiSelect
+                            key={`assessment-mode-${assessmentMode.join(",")}`}
                             options={assessmentModeOptions}
                             value={assessmentMode}
                             onChange={handleAssessmentModeChange}

--- a/components/admin/frameworks/createFramework/AuthorityPublisherSelect.tsx
+++ b/components/admin/frameworks/createFramework/AuthorityPublisherSelect.tsx
@@ -104,6 +104,7 @@ export default function AuthorityPublisherSelect({
 }: AuthorityPublisherSelectProps) {
     return (
         <Select
+            key={`authority-publisher-select-${value || "none"}`}
             value={value || ""}
             onValueChange={(selectedValue) => onValueChange(selectedValue as AuthorityPublisher)}
         >
@@ -125,7 +126,7 @@ export default function AuthorityPublisherSelect({
                         {/* Group Options */}
                         {group.options.map((option) => (
                             <SelectItem 
-                                key={option.value} 
+                                key={`authority-publisher-option-${option.value}`} 
                                 value={option.value}
                                 className="pl-6" // Indent to show hierarchy
                             >

--- a/components/admin/frameworks/createFramework/FrameworkForm.tsx
+++ b/components/admin/frameworks/createFramework/FrameworkForm.tsx
@@ -11,7 +11,6 @@ import {
     CreateFrameworkRequest,
     UpdateFrameworkRequest
 } from "@/interfaces/Framework";
-import Breadcrumbs from "@/components/custom/Breadcrumbs";
 import FormErrorAlert from "@/components/admin/shared/FormErrorAlert";
 import FormActions from "@/components/admin/shared/FormActions";
 import NameVersionFields from "./fields/NameVersionFields";
@@ -28,11 +27,6 @@ interface FrameworkFormProps {
 }
 
 export default function FrameworkForm({ framework, isEditing = false, onCancel, serverErrors, onSubmit }: FrameworkFormProps) {
-    const breadcrumbItems = [
-        { label: 'Frameworks', href: '/admin/compliance-library/frameworks' },
-        { label: isEditing ? 'Edit' : 'Create' },
-    ];
-
     // Basic form state aligned with backend validation contract
     const [formData, setFormData] = useState<CreateFrameworkRequest>({
         name: "",
@@ -192,9 +186,6 @@ export default function FrameworkForm({ framework, isEditing = false, onCancel, 
 
     return (
         <div className="min-h-screen bg-[#FAFAFA] px-2 flex flex-col items-start">
-            {/* Breadcrumb */}
-            <Breadcrumbs items={breadcrumbItems} />
-
             {/* Heading */}
             <h1 className="text-3xl text-[#171717] font-bold mt-4 mb-6">
                 {isEditing ? 'Edit Framework' : 'Create Framework'}

--- a/components/admin/frameworks/createFramework/fields/StatusEffectiveDateFields.tsx
+++ b/components/admin/frameworks/createFramework/fields/StatusEffectiveDateFields.tsx
@@ -32,7 +32,7 @@ export default function StatusEffectiveDateFields({
           Status <span className="text-red-500">*</span>
         </Label>
         <Select
-          key={`status-${formData.status}`}
+          key={`status-${formData.status || "none"}`}
           value={formData.status}
           onValueChange={(value) =>
             onInputChange("status", value as CreateFrameworkRequest["status"])

--- a/components/admin/organizations/OrganizationDetails.tsx
+++ b/components/admin/organizations/OrganizationDetails.tsx
@@ -6,7 +6,6 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import Breadcrumbs from '@/components/custom/Breadcrumbs';
 import ConfirmationDialog from '@/components/custom/ConfirmationDialog';
 import MembersTable from './MembersTable';
 
@@ -104,12 +103,6 @@ const OrganizationDetails: React.FC = () => {
         setRefreshingMembers(false);
     };
 
-    const breadcrumbItems = [
-        { label: 'Customers', href: '/admin/users-administration/customers' },
-        { label: organization?.name || 'Loading...', href: '#' },
-        { label: 'Edit', href: '#' }
-    ];
-
     if (loading) {
         return (
             <div className="flex items-center justify-center h-64">
@@ -130,7 +123,6 @@ const OrganizationDetails: React.FC = () => {
         <div className="space-y-6">
             {/* Header */}
             <div className='w-full'>
-                <Breadcrumbs items={breadcrumbItems} />
                 <div className='w-full flex justify-between items-center flex-wrap'>
                     <h1 className="text-2xl font-bold text-gray-900 mt-2">{organization.name}</h1>
                     <Button

--- a/components/admin/regulatory-submissions/RegulatorySubmissionForm.tsx
+++ b/components/admin/regulatory-submissions/RegulatorySubmissionForm.tsx
@@ -152,12 +152,22 @@ export default function RegulatorySubmissionForm({
       })) || [];
 
     const submitted = regulatorySubmission?.submitted_by_user || regulatorySubmission?.submittedBy;
+    const submittedId = regulatorySubmission?.submitted_by;
     if (submitted) {
       const exists = base.some((opt) => opt.value === submitted.id.toString());
       if (!exists) {
         base.unshift({
           value: submitted.id.toString(),
           label: `${submitted.name} (${submitted.email})`,
+        });
+      }
+    } else if (submittedId) {
+      const idStr = submittedId.toString();
+      const exists = base.some((opt) => opt.value === idStr);
+      if (!exists) {
+        base.unshift({
+          value: idStr,
+          label: `User #${idStr}`,
         });
       }
     }
@@ -354,13 +364,6 @@ export default function RegulatorySubmissionForm({
 
   return (
     <div className="min-h-screen bg-[#FAFAFA] px-6 py-6">
-      <Breadcrumbs
-        items={[
-          { label: "Compliance Library", href: "/admin/compliance-library/frameworks" },
-          { label: "Regulatory Submissions", href: "/admin/compliance-library/regulatory-submissions" },
-          { label: mode === "create" ? "Create" : "Edit" },
-        ]}
-      />
       <div className="mt-6 mb-8">
         <h1 className="text-3xl text-[#171717] font-bold">
           {mode === "create" ? "Create Regulatory Submission" : "Edit Regulatory Submission"}
@@ -610,6 +613,7 @@ export default function RegulatorySubmissionForm({
                 Submitted By <span className="text-red-500">*</span>
               </Label>
               <Select
+                key={`submitted-by-${formData.submitted_by || "none"}-${userOptions.length}`}
                 value={formData.submitted_by ? String(formData.submitted_by) : ""}
                 onValueChange={(value) => handleInputChange("submitted_by", Number(value))}
                 disabled={isLoading || isLoadingUsers}

--- a/components/admin/regulatory-submissions/RegulatorySubmissionsList.tsx
+++ b/components/admin/regulatory-submissions/RegulatorySubmissionsList.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { DataTable } from "@/components/custom/DataTable";
-import Breadcrumbs from "@/components/custom/Breadcrumbs";
 import { useRegulatorySubmissions, useRegulatorySubmissionMutations } from "@/hooks/admin/useRegulatorySubmissions";
 import { RegulatorySubmission, RegulatorySubmissionFilters, RegulatorySubmissionStatusEnum, RegulatorySubmissionTypeEnum } from "@/interfaces/RegulatorySubmission";
 import { ColumnDef } from "@tanstack/react-table";
@@ -167,7 +166,6 @@ export default function RegulatorySubmissionsList() {
   if (error) {
     return (
       <div className="min-h-screen bg-[#FAFAFA] px-6 py-6">
-        <Breadcrumbs items={breadcrumbItems} />
         <Alert variant="destructive" className="mt-6">
           <AlertCircle className="h-4 w-4" />
           <AlertTitle>Error</AlertTitle>
@@ -179,7 +177,6 @@ export default function RegulatorySubmissionsList() {
 
   return (
     <div className="min-h-screen bg-[#FAFAFA] px-6 py-6">
-      <Breadcrumbs items={breadcrumbItems} />
       <div className="flex items-center justify-between mt-6 mb-8">
         <h1 className="text-3xl text-[#171717] font-bold">Regulatory Submissions</h1>
         <Link href="/admin/compliance-library/regulatory-submissions/create">

--- a/components/admin/requirement-controls/RequirementControlForm.tsx
+++ b/components/admin/requirement-controls/RequirementControlForm.tsx
@@ -22,7 +22,6 @@ import { createValidationErrors, validateTextField } from "@/lib/utils/validatio
 import FormErrorAlert from "@/components/admin/shared/FormErrorAlert";
 import FormActions from "@/components/admin/shared/FormActions";
 import Spinner from "@/components/ui/spinner";
-import Breadcrumbs from "@/components/custom/Breadcrumbs";
 import { formatDateForInput } from "@/lib/helpers/date";
 
 interface RequirementControlFormProps {
@@ -83,6 +82,8 @@ export default function RequirementControlForm({
       })) || [];
 
     const rcRequirement = requirementControl?.requirement;
+    // Fallback: if the requirement object isn't embedded, still show the current selection
+    const rcRequirementId = requirementControl?.requirement_id;
     if (rcRequirement) {
       const exists = base.some((opt) => opt.value === rcRequirement.id.toString());
       if (!exists) {
@@ -91,6 +92,14 @@ export default function RequirementControlForm({
           label: `${rcRequirement.reference}${
             rcRequirement.requirement_text ? ` - ${rcRequirement.requirement_text.substring(0, 50)}` : ""
           }`,
+        });
+      }
+    } else if (rcRequirementId) {
+      const exists = base.some((opt) => opt.value === rcRequirementId.toString());
+      if (!exists) {
+        base.unshift({
+          value: rcRequirementId.toString(),
+          label: `Requirement #${rcRequirementId}`,
         });
       }
     }
@@ -106,12 +115,21 @@ export default function RequirementControlForm({
       })) || [];
 
     const rcControl = requirementControl?.control;
+    const rcControlId = requirementControl?.control_id;
     if (rcControl) {
       const exists = base.some((opt) => opt.value === rcControl.id.toString());
       if (!exists) {
         base.unshift({
           value: rcControl.id.toString(),
           label: `${rcControl.reference} - ${rcControl.name}`,
+        });
+      }
+    } else if (rcControlId) {
+      const exists = base.some((opt) => opt.value === rcControlId.toString());
+      if (!exists) {
+        base.unshift({
+          value: rcControlId.toString(),
+          label: `Control #${rcControlId}`,
         });
       }
     }
@@ -127,12 +145,22 @@ export default function RequirementControlForm({
       })) || [];
 
     const rcUser = requirementControl?.user;
+    const rcUserId = requirementControl?.reviewed_by;
     if (rcUser) {
       const exists = base.some((opt) => opt.value === rcUser.id.toString());
       if (!exists) {
         base.unshift({
           value: rcUser.id.toString(),
           label: `${rcUser.name} (${rcUser.email})`,
+        });
+      }
+    } else if (rcUserId) {
+      const idStr = rcUserId.toString();
+      const exists = base.some((opt) => opt.value === idStr);
+      if (!exists) {
+        base.unshift({
+          value: idStr,
+          label: `User #${idStr}`,
         });
       }
     }
@@ -267,12 +295,6 @@ export default function RequirementControlForm({
 
   return (
     <div className="min-h-screen bg-[#FAFAFA] px-6 py-6">
-      <Breadcrumbs
-        items={[
-          { label: "Requirement Controls", href: "/admin/compliance-library/requirement-controls" },
-          { label: mode === "create" ? "Create" : "Edit" },
-        ]}
-      />
       <div className="mt-6 mb-8">
         <h1 className="text-3xl text-[#171717] font-bold">
           {mode === "create" ? "Create Requirement Control" : "Edit Requirement Control"}
@@ -289,6 +311,7 @@ export default function RequirementControlForm({
                 Requirement <span className="text-red-500">*</span>
               </Label>
               <Select
+                key={`requirement-${formData.requirement_id || "none"}`}
                 value={formData.requirement_id ? String(formData.requirement_id) : ""}
                 onValueChange={(value) => handleInputChange("requirement_id", Number(value))}
                 disabled={isLoading}
@@ -320,6 +343,7 @@ export default function RequirementControlForm({
                 Control <span className="text-red-500">*</span>
               </Label>
               <Select
+                key={`control-${formData.control_id || "none"}`}
                 value={formData.control_id ? String(formData.control_id) : ""}
                 onValueChange={(value) => handleInputChange("control_id", Number(value))}
                 disabled={isLoading}
@@ -472,6 +496,7 @@ export default function RequirementControlForm({
             <div>
               <Label className="text-sm font-medium text-gray-900">Reviewed By</Label>
               <Select
+                key={`reviewed-by-${formData.reviewed_by || "none"}-${userOptions.length}`}
                 value={formData.reviewed_by ? String(formData.reviewed_by) : "null"}
                 onValueChange={(value) =>
                   handleInputChange("reviewed_by", value === "null" ? null : Number(value))

--- a/components/admin/requirements/RequirementForm.tsx
+++ b/components/admin/requirements/RequirementForm.tsx
@@ -4,7 +4,6 @@ import React, { useState, useEffect, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Card } from "@/components/ui/card";
 import Spinner from "@/components/ui/spinner";
-import Breadcrumbs from "@/components/custom/Breadcrumbs";
 import { useRequirement, useRequirementMutations, useRequirements } from "@/hooks/admin/useRequirements";
 import { useFrameworks } from "@/hooks/admin/useFrameworks";
 import {
@@ -74,25 +73,65 @@ export default function RequirementForm({ requirementId, mode, serverErrors, onS
     const [tagsInput, setTagsInput] = useState<string>("");
     const [validationErrors, setValidationErrors] = useState<Record<string, string[]>>({});
 
-    const frameworkOptions = useMemo(
-        () =>
+    const frameworkOptions = useMemo(() => {
+        const base =
             frameworks?.map((fw) => ({
                 value: fw.id.toString(),
                 label: fw.name || fw.id.toString(),
-            })) || [],
-        [frameworks]
-    );
+            })) || [];
 
-    const requirementOptions = useMemo(
-        () =>
+        // Include current framework when not present in fetched list
+        const currentId =
+            formData.framework_id ||
+            requirement?.framework_id ||
+            undefined;
+        const currentObj = requirement?.framework;
+
+        if (currentObj) {
+            const exists = base.some((opt) => opt.value === currentObj.id.toString());
+            if (!exists) {
+                base.unshift({
+                    value: currentObj.id.toString(),
+                    label: currentObj.name || `Framework #${currentObj.id}`,
+                });
+            }
+        } else if (currentId) {
+            const idStr = currentId.toString();
+            const exists = base.some((opt) => opt.value === idStr);
+            if (!exists) {
+                base.unshift({
+                    value: idStr,
+                    label: `Framework #${idStr}`,
+                });
+            }
+        }
+
+        return base;
+    }, [frameworks, formData.framework_id, requirement]);
+
+    const requirementOptions = useMemo(() => {
+        const base =
             (requirementList || [])
                 .filter((req: Requirement) => !requirementId || String(req.id) !== String(requirementId))
                 .map((req: Requirement) => ({
                     value: req.id.toString(),
                     label: req.reference || `Requirement #${req.id}`,
-                })),
-        [requirementList, requirementId]
-    );
+                })) || [];
+
+        const selectedIds = [
+            formData.supersedes_req_id ? String(formData.supersedes_req_id) : null,
+            formData.superseded_by_req_id ? String(formData.superseded_by_req_id) : null,
+        ].filter(Boolean) as string[];
+
+        selectedIds.forEach((id) => {
+            const exists = base.some((opt) => opt.value === id);
+            if (!exists) {
+                base.unshift({ value: id, label: `Requirement #${id}` });
+            }
+        });
+
+        return base;
+    }, [requirementList, requirementId, formData.supersedes_req_id, formData.superseded_by_req_id]);
 
     useEffect(() => {
         if (mode === "edit" && requirement) {
@@ -223,10 +262,6 @@ export default function RequirementForm({ requirementId, mode, serverErrors, onS
 
     return (
         <div className="min-h-screen bg-[#FAFAFA] px-6 py-6">
-            <Breadcrumbs items={[
-                { label: 'Requirements', href: '/admin/compliance-library/requirements' },
-                { label: mode === 'create' ? 'Create Requirement' : 'Edit Requirement' },
-            ]} />
 
             <div className="mt-6 mb-8">
                 <h1 className="text-3xl text-[#171717] font-bold">

--- a/components/admin/requirements/RequirementsList.tsx
+++ b/components/admin/requirements/RequirementsList.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { DataTable } from "@/components/custom/DataTable";
-import Breadcrumbs from "@/components/custom/Breadcrumbs";
 import { useRequirements } from "@/hooks/admin/useRequirements";
 import { Requirement, RequirementFilters } from "@/interfaces/Requirement";
 import { ColumnDef } from "@tanstack/react-table";
@@ -19,10 +18,6 @@ export default function RequirementsList() {
     });
 
     const { requirements, loading, pagination, handlePageChange, handleSearch } = useRequirements(filters);
-    const breadcrumbItems = [
-        { label: 'Requirements', href: '/admin/compliance-library/requirements' },
-        { label: 'List' },
-    ];
 
     const handleSearchTerm = (searchTerm: string) => {
         setFilters(prev => ({
@@ -128,7 +123,6 @@ export default function RequirementsList() {
 
     return (
         <div className="min-h-screen bg-[#FAFAFA] px-2 flex flex-col items-start">
-            <Breadcrumbs items={breadcrumbItems} />
             <div className="flex items-center justify-between w-full mt-4 mb-6">
                 <h1 className="text-3xl text-[#171717] font-bold">Requirements</h1>
                 <Link href="/admin/compliance-library/requirements/create">

--- a/components/admin/requirements/fields/CategoryPriorityFields.tsx
+++ b/components/admin/requirements/fields/CategoryPriorityFields.tsx
@@ -41,6 +41,7 @@ export default function CategoryPriorityFields({
           Category <span className="text-red-500">*</span>
         </Label>
         <Select
+          key={`category-${formData.category || "none"}`}
           value={formData.category}
           onValueChange={(value) =>
             onInputChange("category", value as RequirementCategory)
@@ -70,6 +71,7 @@ export default function CategoryPriorityFields({
           Priority <span className="text-red-500">*</span>
         </Label>
         <Select
+          key={`priority-${formData.priority || "none"}`}
           value={formData.priority}
           onValueChange={(value) =>
             onInputChange("priority", value as RequirementPriority)

--- a/components/admin/requirements/fields/ReferenceFrameworkFields.tsx
+++ b/components/admin/requirements/fields/ReferenceFrameworkFields.tsx
@@ -59,6 +59,7 @@ export default function ReferenceFrameworkFields({
           Framework <span className="text-red-500">*</span>
         </Label>
         <Select
+          key={`framework-${formData.framework_id || "none"}-${frameworkOptions.length}`}
           value={formData.framework_id ? String(formData.framework_id) : ""}
           onValueChange={(value) => onInputChange("framework_id", Number(value))}
           disabled={isLoading}

--- a/components/admin/requirements/fields/SupersedesFields.tsx
+++ b/components/admin/requirements/fields/SupersedesFields.tsx
@@ -35,6 +35,7 @@ export default function SupersedesFields({
           Supersedes Requirement
         </Label>
         <Select
+          key={`supersedes-${formData.supersedes_req_id || "none"}`}
           value={formData.supersedes_req_id ? String(formData.supersedes_req_id) : ""}
           onValueChange={(value) =>
             onInputChange("supersedes_req_id", value ? Number(value) : undefined)
@@ -69,6 +70,7 @@ export default function SupersedesFields({
           Superseded By Requirement
         </Label>
         <Select
+          key={`supersededby-${formData.superseded_by_req_id || "none"}`}
           value={
             formData.superseded_by_req_id
               ? String(formData.superseded_by_req_id)


### PR DESCRIPTION
- Eliminated Breadcrumbs component from Controls, Create Control, Control Details, Edit Control, Frameworks, Requirement Controls, and various forms to streamline the user interface.
- This change enhances the overall layout and focuses on the main content without the additional navigation elements.